### PR TITLE
Added a quick way to flash devices without recompiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /esp32_bluetooth_host/.vscode
+/esp32_bluetooth_host/build/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Firmware
 
-Firmware fore the [CreaTeBME](https://github.com/CreaTe-M8-BME/CreaTeBME) sensors.
+Firmware for the [CreaTeBME](https://github.com/CreaTe-M8-BME/CreaTeBME) sensors.
+
+No additional libraries are required. You only need to make sure you have the latest version of the esp32 board manager installed.
+
+## Flashing firmware without needing to compile each time
+
+If you want to flash multiple IMUs quickly without recompiling the firmware every time in the Arduino IDE, you can use the Python scripts provided as follows:
+
+1. Run the setup script to install esptool and setuptools with `python setup_esptool.py`.
+2. In your Arduino IDE, export your sketch as a series of .bin files with Sketch -> Export Compiled Library (you only need to do this once every time your code is updated).
+3. Connect your IMU with a USB cable.
+4. Run `python flash_firmware.py` to flash your sensor.
+
+> [!NOTE]
+> If you get an error regarding the bootloader, make sure to update your esp32 boards manager and recompile the .bin file

--- a/flash_firmware.py
+++ b/flash_firmware.py
@@ -1,0 +1,2 @@
+import os
+os.system("esptool.py -b 460800 --before default_reset --after hard_reset --chip esp32 write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 ./esp32_bluetooth_host/build/esp32.esp32.lolin32/esp32_bluetooth_host.ino.bootloader.bin 0x8000 ./esp32_bluetooth_host/build/esp32.esp32.lolin32/./esp32_bluetooth_host.ino.partitions.bin 0x10000 ./esp32_bluetooth_host/build/esp32.esp32.lolin32/./esp32_bluetooth_host.ino.bin")

--- a/setup_esptool.py
+++ b/setup_esptool.py
@@ -1,0 +1,3 @@
+import subprocess
+import sys
+subprocess.check_call([sys.executable, "-m", "pip", "install", "esptool", "setuptools"])


### PR DESCRIPTION
Added two Python that allow you to quickly flash precompiled binaries to circumvent your Arduino IDE having to recompile every time you want to flash an IMU.